### PR TITLE
Implement game pause when shop opens

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -46,5 +46,5 @@ move_right={
 
 [rendering]
 
-textures/vram_compression/import_etc2_astc=true
 rendering_device/driver.windows="d3d12"
+textures/vram_compression/import_etc2_astc=true

--- a/scripts/catcher.gd
+++ b/scripts/catcher.gd
@@ -16,6 +16,7 @@ var _bomb_shrink_active: bool = false
 var _stripe: ColorRect
 var _catcher_tier: int = -1
 var _rainbow_time: float = 0.0
+var _game_paused: bool = false
 
 @onready var color_rect: ColorRect = $ColorRect
 @onready var collision_shape: CollisionShape2D = $CollisionShape2D
@@ -32,9 +33,13 @@ func _ready() -> void:
 	_setup_combo_label()
 	GameManager.coin_missed.connect(_on_coin_missed)
 	GameManager.bomb_hit.connect(_on_bomb_hit)
+	GameManager.shop_opened.connect(_on_shop_opened)
+	GameManager.shop_closed.connect(_on_shop_closed)
 
 
 func _process(delta: float) -> void:
+	if _game_paused:
+		return
 	var direction := Input.get_axis("move_left", "move_right")
 	position.x += direction * speed * delta
 	var half_width := GameManager.get_catcher_width() / 2.0
@@ -242,4 +247,14 @@ func _setup_trail() -> void:
 	_trail_particles.scale_amount_min = 2.0
 	_trail_particles.scale_amount_max = 4.0
 	_trail_particles.color = Color(0.4, 0.65, 1.0, 0.4)
+
+
+func _on_shop_opened() -> void:
+	_game_paused = true
+	monitoring = false
+
+
+func _on_shop_closed() -> void:
+	_game_paused = false
+	monitoring = true
 	add_child(_trail_particles)

--- a/scripts/coin.gd
+++ b/scripts/coin.gd
@@ -34,6 +34,8 @@ func _ready() -> void:
 
 	_add_glow()
 	_add_trail()
+	GameManager.shop_opened.connect(func(): set_process(false))
+	GameManager.shop_closed.connect(func(): set_process(true))
 
 
 func _process(delta: float) -> void:

--- a/scripts/coin_spawner.gd
+++ b/scripts/coin_spawner.gd
@@ -13,6 +13,8 @@ func _ready() -> void:
 	GameManager.upgrade_purchased.connect(_on_upgrade_purchased)
 	GameManager.frenzy_started.connect(_on_frenzy_started)
 	GameManager.frenzy_ended.connect(_on_frenzy_ended)
+	GameManager.shop_opened.connect(_on_shop_opened)
+	GameManager.shop_closed.connect(_on_shop_closed)
 
 
 func _on_upgrade_purchased(upgrade_id: String) -> void:
@@ -47,3 +49,11 @@ func _on_timer_timeout() -> void:
 		coin.coin_type = coin.CoinType.GOLD
 
 	get_parent().add_child(coin)
+
+
+func _on_shop_opened() -> void:
+	$Timer.paused = true
+
+
+func _on_shop_closed() -> void:
+	$Timer.paused = false

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -9,6 +9,8 @@ signal frenzy_started
 signal frenzy_ended
 signal bomb_hit
 signal ascended(count: int)
+signal shop_opened
+signal shop_closed
 
 const SAVE_PATH: String = "user://save.json"
 const MAX_OFFLINE_SECONDS: float = 28800.0  # 8 hours

--- a/scripts/hud.gd
+++ b/scripts/hud.gd
@@ -67,6 +67,10 @@ func _on_shop_toggle_pressed() -> void:
 		return
 	_shop_open = not _shop_open
 	shop_toggle.text = "Close" if _shop_open else "Shop"
+	if _shop_open:
+		GameManager.shop_opened.emit()
+	else:
+		GameManager.shop_closed.emit()
 	_shop_tween = create_tween().set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_BACK)
 	if _shop_open:
 		upgrade_panel.visible = true


### PR DESCRIPTION
## Summary

Implements a signal-based pause system that pauses all game systems when the shop/upgrade panel opens, allowing players to make upgrade decisions without pressure while coins continue falling in the background.

## Changes

**Core Implementation:**
- Add `shop_opened` and `shop_closed` signals to GameManager (autoload)
- Emit signals from HUD when shop toggle is pressed
- Pause coin spawner Timer when shop opens
- Freeze falling coins by disabling `_process()` when shop opens  
- Pause catcher movement and disable collision detection when shop opens

**Game Behavior:**
- When shop opens:
  - Coins freeze mid-air (no falling, rotation, magnet effects, or spawning)
  - Catcher doesn't move or collect coins
  - UI remains fully interactive (buttons, animations, updates work normally)
  
- When shop closes:
  - All systems immediately resume
  - Coins continue falling from where they froze
  - Normal gameplay resumes

## Design Rationale

**Signal-based approach chosen over `get_tree().paused`:**
- More explicit control (clear what pauses and why)
- Better debugging (can log signal emissions)
- More flexible for future features
- No global state management
- Aligns with existing GameManager signal architecture
- Allows UI (CanvasLayer) to remain fully responsive

## Implementation Details

**Files Modified:**
1. `scripts/game_manager.gd` - Add shop_opened/closed signals
2. `scripts/hud.gd` - Emit signals on shop toggle
3. `scripts/coin_spawner.gd` - Pause Timer when shop opens
4. `scripts/coin.gd` - Freeze coins by disabling process()
5. `scripts/catcher.gd` - Pause movement, disable monitoring

**Code Quality:**
- Minimal changes (~34 lines across 5 files)
- Uses GDScript static typing
- Follows existing naming conventions
- Leverages existing signal patterns

## Fixes
Closes #3: Players can now make calm upgrade decisions without game pressure

## Test Plan

- [ ] Let coins fall, open shop → coins freeze mid-air
- [ ] No new coins spawn while shop is open
- [ ] Catcher doesn't move or collect coins while paused
- [ ] Shop UI remains responsive (buttons work, currency updates)
- [ ] Close shop → coins resume falling from frozen positions
- [ ] Catcher movement and collection work normally after closing
- [ ] Rapidly open/close shop → no glitches or spawn issues
- [ ] Edge case: Start frenzy, open shop → frenzy timer continues (acceptable behavior)
- [ ] Edge case: Get bomb hit, open shop → shrink timer continues (acceptable behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)