### PR TITLE
Enhance frenzy mode with persistent label, screen shake, and background pulse

### DIFF
--- a/scripts/background.gd
+++ b/scripts/background.gd
@@ -3,6 +3,9 @@ extends ColorRect
 var _time: float = 0.0
 var _color_a := Color(0.08, 0.08, 0.18, 1.0)
 var _color_b := Color(0.12, 0.06, 0.22, 1.0)
+var _base_color_a: Color
+var _base_color_b: Color
+var _cycle_speed: float = CYCLE_SPEED
 
 const PALETTES: Array[Array] = [
 	[Color(0.08, 0.08, 0.18, 1.0), Color(0.12, 0.06, 0.22, 1.0)],   # Navy/purple (base)
@@ -16,11 +19,13 @@ const CYCLE_SPEED: float = 0.15
 
 func _ready() -> void:
 	GameManager.ascended.connect(_on_ascended)
+	GameManager.frenzy_started.connect(_on_frenzy_started)
+	GameManager.frenzy_ended.connect(_on_frenzy_ended)
 	_set_palette(GameManager.ascension_count)
 
 
 func _process(delta: float) -> void:
-	_time += delta * CYCLE_SPEED
+	_time += delta * _cycle_speed
 	var t := (sin(_time) + 1.0) * 0.5
 	color = _color_a.lerp(_color_b, t)
 
@@ -33,3 +38,17 @@ func _set_palette(ascension: int) -> void:
 	var idx: int = ascension % PALETTES.size()
 	_color_a = PALETTES[idx][0]
 	_color_b = PALETTES[idx][1]
+	_base_color_a = _color_a
+	_base_color_b = _color_b
+
+
+func _on_frenzy_started() -> void:
+	_color_a = Color(0.02, 0.1, 0.04, 1.0)
+	_color_b = Color(0.06, 0.18, 0.08, 1.0)
+	_cycle_speed = 0.5
+
+
+func _on_frenzy_ended() -> void:
+	_color_a = _base_color_a
+	_color_b = _base_color_b
+	_cycle_speed = CYCLE_SPEED

--- a/scripts/hud.gd
+++ b/scripts/hud.gd
@@ -14,6 +14,9 @@ var _shop_open: bool = false
 var _shop_tween: Tween
 var _currency_pop_tween: Tween
 var _currency_flash_tween: Tween
+var _frenzy_label: Label
+var _frenzy_tween: Tween
+var _shake_tween: Tween
 var _display_font: Font = preload("res://assets/fonts/kenney_future.ttf")
 var _narrow_font: Font = preload("res://assets/fonts/kenney_future_narrow.ttf")
 
@@ -30,6 +33,7 @@ func _ready() -> void:
 	GameManager.milestone_reached.connect(_on_milestone_reached)
 	GameManager.coin_collected.connect(_on_coin_collected)
 	GameManager.frenzy_started.connect(_on_frenzy_started)
+	GameManager.frenzy_ended.connect(_on_frenzy_ended)
 	GameManager.bomb_hit.connect(_on_bomb_hit)
 	GameManager.combo_multiplier_changed.connect(_on_combo_multiplier_changed)
 	currency_label.add_theme_font_override("font", _display_font)
@@ -176,6 +180,8 @@ func _on_ascend_pressed() -> void:
 func _on_coin_collected(value: int, world_position: Vector2) -> void:
 	if value <= 0:
 		return
+	if GameManager.frenzy_active:
+		_screen_shake(4.0, 4, 0.03)
 	# Spawn a small gold circle that arcs up to the currency label
 	var icon := ColorRect.new()
 	icon.custom_minimum_size = Vector2(12.0, 12.0)
@@ -216,6 +222,12 @@ func _pop_currency_label() -> void:
 
 
 func _on_frenzy_started() -> void:
+	# Clean up any existing frenzy label (handles rapid re-frenzy)
+	if _frenzy_label:
+		if _frenzy_tween and _frenzy_tween.is_running():
+			_frenzy_tween.kill()
+		_frenzy_label.queue_free()
+		_frenzy_label = null
 	var lbl := Label.new()
 	lbl.text = "FRENZY!"
 	lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
@@ -230,12 +242,31 @@ func _on_frenzy_started() -> void:
 	lbl.offset_left = -200.0
 	lbl.offset_right = 200.0
 	lbl.offset_top = 80.0
-	var tween := create_tween()
-	tween.tween_property(lbl, "scale", Vector2(1.2, 1.2), 0.15).from(Vector2(0.5, 0.5)).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_BACK)
-	tween.tween_property(lbl, "scale", Vector2(1.0, 1.0), 0.1)
-	tween.tween_interval(1.5)
-	tween.tween_property(lbl, "modulate:a", 0.0, 0.5)
-	tween.tween_callback(lbl.queue_free)
+	_frenzy_label = lbl
+	# Intro animation: scale pop
+	var intro_tween := create_tween()
+	intro_tween.tween_property(lbl, "scale", Vector2(1.2, 1.2), 0.15).from(Vector2(0.5, 0.5)).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_BACK)
+	intro_tween.tween_property(lbl, "scale", Vector2(1.0, 1.0), 0.1)
+	# Start looping pulse after intro
+	intro_tween.tween_callback(func() -> void:
+		_frenzy_tween = create_tween().set_loops()
+		_frenzy_tween.set_ease(Tween.EASE_IN_OUT).set_trans(Tween.TRANS_SINE)
+		_frenzy_tween.tween_property(lbl, "scale", Vector2(1.1, 1.1), 0.3)
+		_frenzy_tween.tween_property(lbl, "scale", Vector2(0.95, 0.95), 0.3)
+	)
+
+
+func _on_frenzy_ended() -> void:
+	if _frenzy_label:
+		if _frenzy_tween and _frenzy_tween.is_running():
+			_frenzy_tween.kill()
+		var fade_tween := create_tween()
+		var lbl_ref: Label = _frenzy_label
+		fade_tween.tween_property(lbl_ref, "modulate:a", 0.0, 0.4)
+		fade_tween.tween_callback(func() -> void:
+			lbl_ref.queue_free()
+		)
+		_frenzy_label = null
 
 
 func _on_bomb_hit() -> void:
@@ -245,14 +276,21 @@ func _on_bomb_hit() -> void:
 	_gold_flash.color = Color(1.0, 0.1, 0.0, 0.3)
 	_flash_tween = create_tween()
 	_flash_tween.tween_property(_gold_flash, "color:a", 0.0, 0.4).set_ease(Tween.EASE_OUT)
-	# Screen shake via camera or offset on the Main node
+	# Screen shake
+	_screen_shake(8.0, 8, 0.04)
+
+
+func _screen_shake(intensity: float, iterations: int, step_time: float) -> void:
+	if _shake_tween and _shake_tween.is_running():
+		_shake_tween.kill()
 	var main_node := get_tree().current_scene
-	if main_node:
-		var shake_tween := create_tween()
-		for i: int in range(8):
-			var offset := Vector2(randf_range(-8.0, 8.0), randf_range(-8.0, 8.0))
-			shake_tween.tween_property(main_node, "position", offset, 0.04)
-		shake_tween.tween_property(main_node, "position", Vector2.ZERO, 0.04)
+	if not main_node:
+		return
+	_shake_tween = create_tween()
+	for i: int in range(iterations):
+		var offset := Vector2(randf_range(-intensity, intensity), randf_range(-intensity, intensity))
+		_shake_tween.tween_property(main_node, "position", offset, step_time)
+	_shake_tween.tween_property(main_node, "position", Vector2.ZERO, step_time)
 
 
 func _on_mute_pressed() -> void:

--- a/scripts/hud.gd
+++ b/scripts/hud.gd
@@ -53,6 +53,7 @@ func _ready() -> void:
 
 func _on_currency_changed(new_amount: int) -> void:
 	currency_label.text = "Coins: %d" % new_amount
+	currency_label.pivot_offset = currency_label.size / 2.0
 	_update_ascend_button()
 
 
@@ -139,6 +140,11 @@ func _create_combo_multiplier_badge() -> void:
 	_combo_multiplier_label.offset_right = -20.0
 	_combo_multiplier_label.offset_top = 20.0
 	_combo_multiplier_label.offset_bottom = 60.0
+	# Wait one frame for layout to resolve, then set pivot for center-scaling
+	await get_tree().process_frame
+	if not is_instance_valid(_combo_multiplier_label):
+		return
+	_combo_multiplier_label.pivot_offset = _combo_multiplier_label.size / 2.0
 
 
 func _on_combo_multiplier_changed(new_multiplier: float) -> void:
@@ -216,6 +222,7 @@ func _pop_currency_label() -> void:
 		_currency_pop_tween.kill()
 	if _currency_flash_tween and _currency_flash_tween.is_running():
 		_currency_flash_tween.kill()
+	currency_label.pivot_offset = currency_label.size / 2.0
 	_currency_pop_tween = create_tween()
 	_currency_pop_tween.tween_property(currency_label, "scale", Vector2(1.15, 1.15), 0.06).set_ease(Tween.EASE_OUT)
 	_currency_pop_tween.tween_property(currency_label, "scale", Vector2(1.0, 1.0), 0.08).set_ease(Tween.EASE_IN)
@@ -243,6 +250,11 @@ func _on_frenzy_started() -> void:
 	lbl.offset_right = 200.0
 	lbl.offset_top = 80.0
 	_frenzy_label = lbl
+	# Wait one frame for layout to resolve, then set pivot for center-scaling
+	await get_tree().process_frame
+	if not is_instance_valid(lbl):
+		return
+	lbl.pivot_offset = lbl.size / 2.0
 	# Intro animation: scale pop
 	var intro_tween := create_tween()
 	intro_tween.tween_property(lbl, "scale", Vector2(1.2, 1.2), 0.15).from(Vector2(0.5, 0.5)).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_BACK)
@@ -310,6 +322,7 @@ func _flash_currency_label() -> void:
 		_currency_flash_tween.kill()
 	if _currency_pop_tween and _currency_pop_tween.is_running():
 		_currency_pop_tween.kill()
+	currency_label.pivot_offset = currency_label.size / 2.0
 	_currency_flash_tween = create_tween()
 	currency_label.add_theme_color_override("font_color", Color(1.0, 1.0, 1.0, 1.0))
 	_currency_flash_tween.tween_property(currency_label, "scale", Vector2(1.3, 1.3), 0.1).set_ease(Tween.EASE_OUT)
@@ -352,6 +365,11 @@ func _create_milestone_label() -> void:
 	_milestone_label.offset_right = 300.0
 	_milestone_label.offset_top = -60.0
 	_milestone_label.offset_bottom = 60.0
+	# Wait one frame for layout to resolve, then set pivot for center-scaling
+	await get_tree().process_frame
+	if not is_instance_valid(_milestone_label):
+		return
+	_milestone_label.pivot_offset = _milestone_label.size / 2.0
 
 
 func _on_milestone_reached(amount: int) -> void:
@@ -362,6 +380,12 @@ func _show_milestone_celebration(amount: int) -> void:
 	_milestone_label.visible = true
 	_milestone_label.text = "%d COINS!" % amount
 	_milestone_label.scale = Vector2(0.5, 0.5)
+
+	# Update pivot after text change for center-scaling
+	await get_tree().process_frame
+	if not is_instance_valid(_milestone_label):
+		return
+	_milestone_label.pivot_offset = _milestone_label.size / 2.0
 
 	# Big gold screen flash
 	if _flash_tween and _flash_tween.is_running():


### PR DESCRIPTION
## Summary
- "FRENZY!" label now persists and pulses for the full 5s frenzy duration (was disappearing after ~2.25s)
- Mild screen shake (4px) on every coin catch during frenzy
- Background shifts to dark green palette with faster cycle during frenzy, restores after
- Extracted reusable `_screen_shake(intensity, iterations, step_time)` method shared by bomb and frenzy
- Bomb shake refactored to use the same method (no behavior change)

Closes #21

## Test plan
- [ ] Trigger frenzy — "FRENZY!" text stays visible and pulses for full 5s
- [ ] Frenzy label fades out gracefully when frenzy ends
- [ ] Background turns dark green during frenzy, returns to normal after
- [ ] Coins caught during frenzy cause mild screen shake
- [ ] Bomb during frenzy — bomb shake replaces frenzy shake cleanly
- [ ] Rapid back-to-back frenzies don't stack labels
- [ ] 120 FPS, 0 orphan nodes throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)