### PR TITLE
Modernize UI with Kenney UI Pack styled buttons and panels

### DIFF
--- a/assets/ui_theme.tres
+++ b/assets/ui_theme.tres
@@ -1,0 +1,80 @@
+[gd_resource type="Theme" load_steps=10 format=3]
+
+[ext_resource type="Texture2D" path="res://UI Pack/PNG/Blue/Default/button_rectangle_depth_flat.png" id="1_blue_normal"]
+[ext_resource type="Texture2D" path="res://UI Pack/PNG/Blue/Default/button_rectangle_flat.png" id="2_blue_hover"]
+[ext_resource type="Texture2D" path="res://UI Pack/PNG/Grey/Default/button_rectangle_depth_flat.png" id="3_grey_depth"]
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_btn_normal"]
+texture = ExtResource("1_blue_normal")
+texture_margin_left = 10.0
+texture_margin_top = 10.0
+texture_margin_right = 10.0
+texture_margin_bottom = 10.0
+content_margin_left = 12.0
+content_margin_top = 8.0
+content_margin_right = 12.0
+content_margin_bottom = 8.0
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_btn_hover"]
+texture = ExtResource("2_blue_hover")
+texture_margin_left = 10.0
+texture_margin_top = 10.0
+texture_margin_right = 10.0
+texture_margin_bottom = 10.0
+content_margin_left = 12.0
+content_margin_top = 8.0
+content_margin_right = 12.0
+content_margin_bottom = 8.0
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_btn_pressed"]
+texture = ExtResource("3_grey_depth")
+texture_margin_left = 10.0
+texture_margin_top = 10.0
+texture_margin_right = 10.0
+texture_margin_bottom = 10.0
+content_margin_left = 12.0
+content_margin_top = 8.0
+content_margin_right = 12.0
+content_margin_bottom = 8.0
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_btn_disabled"]
+texture = ExtResource("3_grey_depth")
+texture_margin_left = 10.0
+texture_margin_top = 10.0
+texture_margin_right = 10.0
+texture_margin_bottom = 10.0
+content_margin_left = 12.0
+content_margin_top = 8.0
+content_margin_right = 12.0
+content_margin_bottom = 8.0
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_btn_focus"]
+texture = ExtResource("1_blue_normal")
+texture_margin_left = 10.0
+texture_margin_top = 10.0
+texture_margin_right = 10.0
+texture_margin_bottom = 10.0
+content_margin_left = 12.0
+content_margin_top = 8.0
+content_margin_right = 12.0
+content_margin_bottom = 8.0
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_panel"]
+texture = ExtResource("3_grey_depth")
+texture_margin_left = 10.0
+texture_margin_top = 10.0
+texture_margin_right = 10.0
+texture_margin_bottom = 10.0
+content_margin_left = 12.0
+content_margin_top = 8.0
+content_margin_right = 12.0
+content_margin_bottom = 8.0
+modulate_color = Color(0.25, 0.28, 0.38, 0.92)
+
+[resource]
+Button/styles/normal = SubResource("StyleBoxTexture_btn_normal")
+Button/styles/hover = SubResource("StyleBoxTexture_btn_hover")
+Button/styles/pressed = SubResource("StyleBoxTexture_btn_pressed")
+Button/styles/disabled = SubResource("StyleBoxTexture_btn_disabled")
+Button/styles/focus = SubResource("StyleBoxTexture_btn_focus")
+PanelContainer/styles/panel = SubResource("StyleBoxTexture_panel")

--- a/scenes/hud.tscn
+++ b/scenes/hud.tscn
@@ -1,13 +1,15 @@
-[gd_scene load_steps=3 format=3 uid="uid://hud_scene_001"]
+[gd_scene load_steps=4 format=3 uid="uid://hud_scene_001"]
 
 [ext_resource type="Script" path="res://scripts/hud.gd" id="1_script"]
 [ext_resource type="PackedScene" path="res://scenes/upgrade_button.tscn" id="2_upgrade_btn"]
+[ext_resource type="Theme" path="res://assets/ui_theme.tres" id="3_theme"]
 
 [node name="HUD" type="CanvasLayer"]
 script = ExtResource("1_script")
 upgrade_button_scene = ExtResource("2_upgrade_btn")
 
 [node name="TopBar" type="MarginContainer" parent="."]
+theme = ExtResource("3_theme")
 anchors_preset = 10
 anchor_right = 1.0
 offset_bottom = 70.0
@@ -26,6 +28,7 @@ horizontal_alignment = 1
 
 [node name="MuteButton" type="Button" parent="."]
 unique_name_in_owner = true
+theme = ExtResource("3_theme")
 anchors_preset = 1
 anchor_left = 1.0
 anchor_right = 1.0
@@ -39,6 +42,7 @@ text = "🔊"
 
 [node name="UpgradePanel" type="PanelContainer" parent="."]
 unique_name_in_owner = true
+theme = ExtResource("3_theme")
 anchors_preset = 12
 anchor_top = 1.0
 anchor_right = 1.0
@@ -61,6 +65,7 @@ theme_override_constants/separation = 6
 
 [node name="ShopToggle" type="Button" parent="."]
 unique_name_in_owner = true
+theme = ExtResource("3_theme")
 z_index = 1
 anchors_preset = 7
 anchor_left = 0.5

--- a/scenes/upgrade_button.tscn
+++ b/scenes/upgrade_button.tscn
@@ -52,5 +52,5 @@ unique_name_in_owner = true
 layout_mode = 2
 custom_minimum_size = Vector2(120, 40)
 theme_override_font_sizes/font_size = 16
-theme_override_colors/font_color = Color(1, 0.84, 0, 1)
+theme_override_colors/font_color = Color(1, 1, 1, 1)
 text = "Buy: 100"

--- a/scenes/upgrade_button.tscn
+++ b/scenes/upgrade_button.tscn
@@ -1,10 +1,24 @@
-[gd_scene load_steps=2 format=3 uid="uid://upgrade_btn_001"]
+[gd_scene load_steps=4 format=3 uid="uid://upgrade_btn_001"]
 
 [ext_resource type="Script" path="res://scripts/upgrade_button.gd" id="1_script"]
+[ext_resource type="Texture2D" path="res://UI Pack/PNG/Grey/Default/button_rectangle_depth_flat.png" id="2_card_bg"]
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_card"]
+texture = ExtResource("2_card_bg")
+texture_margin_left = 10.0
+texture_margin_top = 10.0
+texture_margin_right = 10.0
+texture_margin_bottom = 10.0
+content_margin_left = 10.0
+content_margin_top = 6.0
+content_margin_right = 10.0
+content_margin_bottom = 6.0
+modulate_color = Color(0.2, 0.22, 0.32, 0.85)
 
 [node name="UpgradeButton" type="PanelContainer"]
 script = ExtResource("1_script")
 custom_minimum_size = Vector2(0, 50)
+theme_override_styles/panel = SubResource("StyleBoxTexture_card")
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2

--- a/scripts/hud.gd
+++ b/scripts/hud.gd
@@ -100,6 +100,7 @@ func _create_ascension_ui() -> void:
 	_update_ascension_label()
 	# Ascend button in shop area
 	_ascend_button = Button.new()
+	_ascend_button.theme = preload("res://assets/ui_theme.tres")
 	_ascend_button.text = "ASCEND"
 	_ascend_button.custom_minimum_size = Vector2(200.0, 40.0)
 	_ascend_button.add_theme_font_size_override("font_size", 18)

--- a/scripts/upgrade_button.gd
+++ b/scripts/upgrade_button.gd
@@ -17,6 +17,9 @@ const UPGRADE_ICONS: Dictionary = {
 	"catcher_width": preload("res://assets/textures/icon_arrow_right.png"),
 	"magnet": preload("res://assets/textures/icon_circle.png"),
 }
+const BUY_STYLE_AFFORD: Texture2D = preload("res://UI Pack/PNG/Yellow/Default/button_rectangle_depth_flat.png")
+const BUY_STYLE_UNAFFORD: Texture2D = preload("res://UI Pack/PNG/Grey/Default/button_rectangle_depth_flat.png")
+const BUY_STYLE_GREEN: Texture2D = preload("res://UI Pack/PNG/Green/Default/button_rectangle_depth_flat.png")
 
 var upgrade_id: String = ""
 var _segment_rects: Array[ColorRect] = []
@@ -27,6 +30,9 @@ var _pulse_tween: Tween
 var _shake_tween: Tween
 var _purchase_sound: AudioStreamPlayer
 var _reject_sound: AudioStreamPlayer
+var _style_afford: StyleBoxTexture
+var _style_unafford: StyleBoxTexture
+var _style_green: StyleBoxTexture
 
 @onready var name_label: Label = %NameLabel
 @onready var effect_label: Label = %EffectLabel
@@ -48,6 +54,10 @@ func _ready() -> void:
 	_create_segment_bar()
 	_setup_icon()
 	_setup_sounds()
+	_style_afford = _create_buy_style(BUY_STYLE_AFFORD)
+	_style_unafford = _create_buy_style(BUY_STYLE_UNAFFORD)
+	_style_green = _create_buy_style(BUY_STYLE_GREEN)
+	_apply_buy_style(_style_unafford)
 	_update_display()
 
 
@@ -139,17 +149,38 @@ func _update_segments(level: int) -> void:
 		_segment_rects[i].color = fill_color if i < filled else EMPTY_COLOR
 
 
+func _create_buy_style(texture: Texture2D) -> StyleBoxTexture:
+	var style := StyleBoxTexture.new()
+	style.texture = texture
+	style.texture_margin_left = 10.0
+	style.texture_margin_top = 10.0
+	style.texture_margin_right = 10.0
+	style.texture_margin_bottom = 10.0
+	style.content_margin_left = 8.0
+	style.content_margin_top = 4.0
+	style.content_margin_right = 8.0
+	style.content_margin_bottom = 4.0
+	return style
+
+
+func _apply_buy_style(style: StyleBoxTexture) -> void:
+	buy_button.add_theme_stylebox_override("normal", style)
+	buy_button.add_theme_stylebox_override("hover", style)
+	buy_button.add_theme_stylebox_override("pressed", style)
+
+
 func _update_afford_cue(affordable: bool) -> void:
 	if affordable:
 		modulate.a = 1.0
 		buy_button.add_theme_color_override("font_color", AFFORD_COLOR)
+		_apply_buy_style(_style_afford)
 		if not _was_affordable:
-			# Just became affordable — start pulse
 			_was_affordable = true
 			_start_pulse()
 	else:
 		modulate.a = 0.7
 		buy_button.add_theme_color_override("font_color", UNAFFORD_COLOR)
+		_apply_buy_style(_style_unafford)
 		if _was_affordable:
 			_was_affordable = false
 			_stop_pulse()
@@ -169,6 +200,7 @@ func _stop_pulse() -> void:
 
 
 func _animate_purchase() -> void:
+	_apply_buy_style(_style_green)
 	var tween := create_tween()
 	tween.tween_property(self, "scale", Vector2(1.05, 1.05), 0.08).set_ease(Tween.EASE_OUT)
 	tween.tween_property(self, "scale", Vector2(1.0, 1.0), 0.12).set_ease(Tween.EASE_IN_OUT)
@@ -176,6 +208,8 @@ func _animate_purchase() -> void:
 	buy_button.add_theme_color_override("font_color", Color(1.0, 1.0, 1.0, 1.0))
 	tween.tween_callback(func() -> void:
 		buy_button.add_theme_color_override("font_color", original_color)
+		var affordable := GameManager.currency >= GameManager.get_upgrade_cost(upgrade_id)
+		_apply_buy_style(_style_afford if affordable else _style_unafford)
 	)
 	if _purchase_sound:
 		_purchase_sound.play()

--- a/scripts/upgrade_button.gd
+++ b/scripts/upgrade_button.gd
@@ -8,7 +8,7 @@ const TIER_COLORS: Array[Color] = [
 	Color(0.8, 0.4, 1.0, 1.0),    # Purple (tier 3+)
 ]
 const EMPTY_COLOR := Color(0.2, 0.2, 0.2, 1.0)
-const AFFORD_COLOR := Color(1.0, 0.84, 0.0, 1.0)
+const AFFORD_COLOR := Color(1.0, 1.0, 1.0, 1.0)
 const UNAFFORD_COLOR := Color(0.5, 0.5, 0.5, 1.0)
 const UPGRADE_ICONS: Dictionary = {
 	"spawn_rate": preload("res://assets/textures/icon_repeat.png"),


### PR DESCRIPTION
## Summary
- Add Godot Theme resource (`assets/ui_theme.tres`) using Kenney UI Pack button/panel PNGs as NinePatch StyleBoxTexture resources
- Style HUD buttons (Shop, Mute, Close, Ascend) with blue Kenney depth buttons
- Style upgrade cards with dark-tinted panel backgrounds and yellow/grey/green buy buttons that swap based on affordability
- Cache StyleBoxTexture instances to avoid per-frame allocation during gameplay

## Test plan
- [ ] Launch game, open shop — verify styled dark card backgrounds with yellow buy buttons
- [ ] Purchase an upgrade — verify green flash on buy button, segment fills, cost increases
- [ ] Set low currency — verify grey buy buttons with dimmed cards
- [ ] Check mute button and shop toggle have blue Kenney button styling
- [ ] Run `validate-all` and `validate-ui` — 0 issues
- [ ] Check `performance` — 0 orphan nodes, stable FPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)