### PR TITLE
Fix catcher squish animation centering

### DIFF
--- a/scripts/catcher.gd
+++ b/scripts/catcher.gd
@@ -134,6 +134,7 @@ func _apply_upgrades() -> void:
 	color_rect.offset_right = w / 2.0
 	color_rect.offset_top = -10.0
 	color_rect.offset_bottom = 10.0
+	color_rect.pivot_offset = Vector2(w / 2.0, 10.0)
 	collision_shape.shape.size = Vector2(w, 20.0)
 	_update_catcher_visual()
 


### PR DESCRIPTION
## Summary
- Set `pivot_offset` on the catcher `ColorRect` to its visual center so squash-bounce and motion stretch animations scale symmetrically instead of from the top-left corner

## Test plan
- [x] Headless lint passes
- [x] `validate-all` and `validate-ui` pass
- [x] 0 orphan nodes, FPS >= 60
- [x] Visual verification: squish animation centered on catcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)