### PR TITLE
Triple viewport width and convert shop to popup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-FlexCoins is a 2D idle falling-coin collector game built with **Godot 4.6** using **GDScript**. Coins spawn at the top of a portrait viewport (720x1280), fall downward, and the player moves a catcher left/right to collect them for currency. Includes an upgrade shop and combo multiplier system. Every session starts fresh.
+FlexCoins is a 2D idle falling-coin collector game built with **Godot 4.6** using **GDScript**. Coins spawn at the top of a landscape viewport (2160x1280), fall downward, and the player moves a catcher left/right to collect them for currency. Includes an upgrade shop (centered popup) and combo multiplier system. Every session starts fresh.
 
 ## Engine & Language
 
 - **Godot 4.6** with Forward Plus renderer
 - **GDScript** (not C# or GDExtension)
-- Viewport: 720x1280 (portrait)
+- Viewport: 2160x1280 (landscape)
 
 ## Development Commands
 
@@ -145,14 +145,15 @@ python3 tools/devtools.py quit
 ### Scene Tree (main.tscn)
 ```
 Main (Node2D)
-├── Background (ColorRect, 720x1280, dark navy)
+├── Background (ColorRect, 2160x1280, dark navy)
 ├── CoinSpawner (Node2D, scripts/coin_spawner.gd)
 │   └── Timer (dynamic interval from upgrades)
-├── Catcher (instanced, positioned at 360,1000)
+├── Catcher (instanced, positioned at 1080,960)
 │   └── spawns FloatingText on coin collection
 └── HUD (instanced, CanvasLayer)
-    ├── TopBar > %CurrencyLabel (gold, font 32)
-    └── UpgradePanel (bottom 260px, 4 upgrade buttons)
+    ├── TopBar > %CurrencyLabel (gold, font 48)
+    ├── BottomBar (Shop + Settings buttons, bottom center)
+    └── UpgradePanel (centered popup 500x600, z_index: 160)
 ```
 
 ### Autoloads
@@ -218,8 +219,8 @@ Tier progression is automatic and triggered in `catcher.gd:_update_catcher_visua
 - `CORE_UPGRADES`: `["spawn_rate", "coin_value", "catcher_speed", "catcher_width"]` (magnet excluded from requirements and reset)
 
 **UI Integration:**
-- Ascend button created dynamically in `hud.gd:_create_ascension_ui()` (lines 81–101)
-- Ascension label displays purple text below currency (line 106: `Color(0.8, 0.6, 1.0)`)
+- Ascend button created dynamically in `hud.gd:_create_ascension_ui()`
+- Ascension label displays purple text below currency (`Color(0.8, 0.6, 1.0)` in `_create_ascension_ui()`)
 - Ascension triggers milestone celebration with "ASCENDED!" text overlay and gold flash animation
 
 ### Upgrade System
@@ -300,19 +301,23 @@ floating_text.z_index = 250  # Floats above upgrade buttons
 
 ```
 Main (Node2D, z_index: 0)
-├── Background (ColorRect, 720x1280, dark navy, z_index: -1)
+├── Background (ColorRect, 2160x1280, dark navy, z_index: -1)
 ├── CoinSpawner (Node2D, z_index: 0)
 │   ├── Timer (dynamic interval from upgrades)
 │   └── [Coins instantiated with z_index: 10]
-├── Catcher (Area2D, positioned at 360,1000, z_index: 20)
+├── Catcher (Area2D, positioned at 1080,960, z_index: 20)
 │   ├── ColorRect (dynamic width/height)
 │   ├── CollisionShape2D (duplicated)
 │   └── [FloatingText children spawned with z_index: 250]
 └── HUD (CanvasLayer, layer: 1)
     ├── TopBar (Control, anchors: top|left)
-    │   └── CurrencyLabel (Label, gold font 32, z_index: 100)
-    └── UpgradePanel (PanelContainer, anchors: bottom|left|right, z_index: 100)
-        └── VBoxContainer
+    │   └── CurrencyLabel (Label, gold font 48)
+    ├── BottomBar (HBoxContainer, bottom center)
+    │   ├── ShopToggle (Button) - "Shop"
+    │   └── GearButton (Button) - "⚙"
+    ├── ShopBackdrop (ColorRect, full screen, z_index: 150)
+    └── UpgradePanel (PanelContainer, centered popup 500x600, z_index: 160)
+        └── Header ("Shop" + Close button) + ScrollContainer
             └── [UpgradeButton instances, created programmatically]
 ```
 
@@ -320,7 +325,7 @@ Main (Node2D, z_index: 0)
 - Background (`z_index: -1`) renders first, behind coins and catcher.
 - Coins (`z_index: 10`) and Catcher (`z_index: 20`) render in world space above background.
 - HUD on CanvasLayer (layer 1) floats above the world.
-- Upgrade buttons (`z_index: 100`) are visible but below popups.
+- Upgrade buttons inside shop popup (`z_index: 160`) render above the shop backdrop (`z_index: 150`).
 - Floating text (`z_index: 250`) appears on top.
 
 **Node Placement Rules:**

--- a/project.godot
+++ b/project.godot
@@ -22,7 +22,7 @@ DevTools="*res://scripts/dev_tools.gd"
 
 [display]
 
-window/size/viewport_width=720
+window/size/viewport_width=2160
 window/size/viewport_height=1280
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"

--- a/scenes/hud.tscn
+++ b/scenes/hud.tscn
@@ -29,13 +29,19 @@ horizontal_alignment = 1
 [node name="UpgradePanel" type="PanelContainer" parent="."]
 unique_name_in_owner = true
 theme = ExtResource("3_theme")
-anchors_preset = 12
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_top = -320.0
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -250.0
+offset_top = -300.0
+offset_right = 250.0
+offset_bottom = 300.0
+custom_minimum_size = Vector2(500, 600)
 grow_horizontal = 2
-grow_vertical = 0
+grow_vertical = 2
+z_index = 160
 
 [node name="MarginContainer" type="MarginContainer" parent="UpgradePanel"]
 layout_mode = 2

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -12,7 +12,7 @@
 [node name="Main" type="Node2D"]
 
 [node name="Background" type="ColorRect" parent="."]
-offset_right = 720.0
+offset_right = 2160.0
 offset_bottom = 1280.0
 color = Color(0.08, 0.08, 0.18, 1)
 script = ExtResource("6_bg_script")
@@ -24,7 +24,7 @@ coin_scene = ExtResource("2_coin_scene")
 [node name="Timer" type="Timer" parent="CoinSpawner"]
 
 [node name="Catcher" parent="." instance=ExtResource("3_catcher_scene")]
-position = Vector2(360, 960)
+position = Vector2(1080, 960)
 floating_text_scene = ExtResource("5_float_text")
 
 [node name="HUD" parent="." instance=ExtResource("4_hud_scene")]

--- a/scripts/hud.gd
+++ b/scripts/hud.gd
@@ -35,6 +35,9 @@ var _settings_panel: PanelContainer
 var _settings_backdrop: Control
 var _settings_open: bool = false
 var _settings_tween: Tween
+var _shop_backdrop: ColorRect
+var _shop_close_button: Button
+var _bottom_bar: HBoxContainer
 var _sound_toggle: Button
 var _fullscreen_toggle: Button
 var _display_font: Font = preload("res://assets/fonts/kenney_future.ttf")
@@ -62,9 +65,12 @@ func _ready() -> void:
 	_create_upgrade_buttons()
 	shop_toggle.pressed.connect(_on_shop_toggle_pressed)
 	_create_settings_ui()
-	# Start with shop hidden off-screen
+	_create_bottom_bar()
+	_create_shop_popup_ui()
+	# Start with shop hidden (popup style)
 	upgrade_panel.visible = false
-	upgrade_panel.offset_top = 0.0
+	upgrade_panel.scale = Vector2(0.8, 0.8)
+	upgrade_panel.modulate.a = 0.0
 	_create_gold_flash_overlay()
 	_create_milestone_label()
 	_create_ascension_ui()
@@ -98,29 +104,127 @@ func _create_upgrade_buttons() -> void:
 func _on_shop_toggle_pressed() -> void:
 	if _shop_tweening:
 		return
-	# Close settings panel if open (mutual exclusion)
 	if _settings_open:
 		_close_settings()
-	_shop_open = not _shop_open
+	if _shop_open:
+		_close_shop()
+	else:
+		_open_shop()
+
+
+func _open_shop() -> void:
+	_shop_open = true
 	_shop_tweening = true
-	shop_toggle.text = "Close" if _shop_open else "Shop"
-	if _shop_open:
-		GameManager.shop_opened.emit()
-	else:
-		GameManager.shop_closed.emit()
+	GameManager.shop_opened.emit()
+	_shop_backdrop.visible = true
+	upgrade_panel.visible = true
+	upgrade_panel.scale = Vector2(0.8, 0.8)
+	upgrade_panel.modulate.a = 0.0
+	upgrade_panel.pivot_offset = upgrade_panel.size / 2.0
+	if _shop_tween and _shop_tween.is_running():
+		_shop_tween.kill()
 	_shop_tween = create_tween().set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_BACK)
-	if _shop_open:
-		upgrade_panel.visible = true
-		upgrade_panel.offset_top = 0.0
-		_shop_tween.tween_property(upgrade_panel, "offset_top", -320.0, 0.3)
-		_shop_tween.tween_callback(func() -> void: _shop_tweening = false)
-	else:
-		_shop_tween.set_trans(Tween.TRANS_QUAD)
-		_shop_tween.tween_property(upgrade_panel, "offset_top", 0.0, 0.2)
-		_shop_tween.tween_callback(func() -> void:
-			upgrade_panel.visible = false
-			_shop_tweening = false
-		)
+	_shop_tween.tween_property(upgrade_panel, "scale", Vector2(1.0, 1.0), 0.2)
+	_shop_tween.parallel().tween_property(upgrade_panel, "modulate:a", 1.0, 0.15)
+	_shop_tween.tween_callback(func() -> void: _shop_tweening = false)
+
+
+func _close_shop() -> void:
+	if not _shop_open:
+		return
+	_shop_open = false
+	_shop_tweening = true
+	GameManager.shop_closed.emit()
+	if _shop_tween and _shop_tween.is_running():
+		_shop_tween.kill()
+	_shop_tween = create_tween().set_ease(Tween.EASE_IN).set_trans(Tween.TRANS_QUAD)
+	_shop_tween.tween_property(upgrade_panel, "scale", Vector2(0.8, 0.8), 0.15)
+	_shop_tween.parallel().tween_property(upgrade_panel, "modulate:a", 0.0, 0.15)
+	_shop_tween.tween_callback(func() -> void:
+		upgrade_panel.visible = false
+		_shop_backdrop.visible = false
+		_shop_tweening = false
+	)
+
+
+func _on_shop_backdrop_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.pressed:
+		_close_shop()
+
+
+func _create_bottom_bar() -> void:
+	_bottom_bar = HBoxContainer.new()
+	_bottom_bar.add_theme_constant_override("separation", 12)
+	add_child(_bottom_bar)
+	_bottom_bar.anchors_preset = Control.PRESET_CENTER_BOTTOM
+	_bottom_bar.anchor_left = 0.5
+	_bottom_bar.anchor_right = 0.5
+	_bottom_bar.anchor_top = 1.0
+	_bottom_bar.anchor_bottom = 1.0
+	_bottom_bar.offset_left = -90.0
+	_bottom_bar.offset_top = -50.0
+	_bottom_bar.offset_right = 90.0
+	_bottom_bar.grow_horizontal = Control.GROW_DIRECTION_BOTH
+	_bottom_bar.grow_vertical = Control.GROW_DIRECTION_BEGIN
+	# Reparent ShopToggle into the bottom bar
+	shop_toggle.reparent(_bottom_bar)
+	shop_toggle.custom_minimum_size = Vector2(100, 40)
+	# Move gear button from top-right into bottom bar
+	_gear_button.reparent(_bottom_bar)
+	_gear_button.anchors_preset = Control.PRESET_TOP_LEFT
+	_gear_button.anchor_left = 0.0
+	_gear_button.anchor_right = 0.0
+	_gear_button.offset_left = 0.0
+	_gear_button.offset_top = 0.0
+	_gear_button.offset_right = 0.0
+	_gear_button.offset_bottom = 0.0
+	_gear_button.custom_minimum_size = Vector2(50, 40)
+	_gear_button.grow_horizontal = Control.GROW_DIRECTION_END
+
+
+func _create_shop_popup_ui() -> void:
+	# Semi-transparent backdrop behind popup
+	_shop_backdrop = ColorRect.new()
+	_shop_backdrop.color = Color(0.0, 0.0, 0.0, 0.5)
+	_shop_backdrop.mouse_filter = Control.MOUSE_FILTER_STOP
+	_shop_backdrop.visible = false
+	_shop_backdrop.z_index = 150
+	add_child(_shop_backdrop)
+	_shop_backdrop.anchors_preset = Control.PRESET_FULL_RECT
+	_shop_backdrop.gui_input.connect(_on_shop_backdrop_input)
+	# Add header with title + close button inside upgrade panel
+	var margin_container: MarginContainer = upgrade_panel.get_child(0)
+	var scroll_container: ScrollContainer = margin_container.get_child(0)
+	margin_container.remove_child(scroll_container)
+	var wrapper: VBoxContainer = VBoxContainer.new()
+	wrapper.add_theme_constant_override("separation", 8)
+	margin_container.add_child(wrapper)
+	# Header row
+	var header: HBoxContainer = HBoxContainer.new()
+	wrapper.add_child(header)
+	var title: Label = Label.new()
+	title.text = "Shop"
+	title.add_theme_font_override("font", _display_font)
+	title.add_theme_font_size_override("font_size", 28)
+	title.add_theme_color_override("font_color", Color(1.0, 0.84, 0.0, 1.0))
+	header.add_child(title)
+	var spacer: Control = Control.new()
+	spacer.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	header.add_child(spacer)
+	_shop_close_button = Button.new()
+	_shop_close_button.theme = preload("res://assets/ui_theme.tres")
+	_shop_close_button.text = "\u2715"
+	_shop_close_button.add_theme_font_size_override("font_size", 20)
+	_shop_close_button.custom_minimum_size = Vector2(40, 40)
+	_shop_close_button.pressed.connect(_close_shop)
+	header.add_child(_shop_close_button)
+	# Re-add scroll container below header
+	scroll_container.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	wrapper.add_child(scroll_container)
+	# Set pivot for popup animation
+	await get_tree().process_frame
+	if is_instance_valid(upgrade_panel):
+		upgrade_panel.pivot_offset = upgrade_panel.size / 2.0
 
 
 func _create_ascension_ui() -> void:
@@ -176,7 +280,7 @@ func _create_combo_multiplier_badge() -> void:
 	_combo_multiplier_label.add_theme_color_override("font_shadow_color", Color(0.0, 0.0, 0.0, 0.4))
 	_combo_multiplier_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	_combo_multiplier_label.visible = false
-	_combo_multiplier_label.z_index = 150
+	_combo_multiplier_label.z_index = 140
 	add_child(_combo_multiplier_label)
 	# Set anchors_preset after add_child so anchors resolve against parent size
 	_combo_multiplier_label.anchors_preset = Control.PRESET_TOP_RIGHT
@@ -397,7 +501,7 @@ func _spawn_combo_threshold_flash() -> void:
 
 
 func _spawn_combo_threshold_particles() -> void:
-	var burst := CPUParticles2D.new()
+	var burst: CPUParticles2D = CPUParticles2D.new()
 	burst.emitting = true
 	burst.one_shot = true
 	burst.explosiveness = 1.0
@@ -412,8 +516,8 @@ func _spawn_combo_threshold_particles() -> void:
 	burst.scale_amount_min = 0.1
 	burst.scale_amount_max = 0.2
 	burst.color = Color(1.0, 0.7, 0.0, 0.9)
-	var wrapper := Node2D.new()
-	var vp_size := get_viewport().get_visible_rect().size
+	var wrapper: Node2D = Node2D.new()
+	var vp_size: Vector2 = get_viewport().get_visible_rect().size
 	wrapper.position = Vector2(vp_size.x - 135.0, 40.0)
 	add_child(wrapper)
 	wrapper.add_child(burst)
@@ -435,7 +539,7 @@ func _on_coin_collected(value: int, world_position: Vector2) -> void:
 	if GameManager.frenzy_active:
 		_screen_shake(4.0, 4, 0.03)
 	# Spawn a small gold circle that arcs up to the currency label
-	var icon := ColorRect.new()
+	var icon: ColorRect = ColorRect.new()
 	icon.custom_minimum_size = Vector2(12.0, 12.0)
 	icon.size = Vector2(12.0, 12.0)
 	icon.color = Color(1.0, 0.84, 0.0, 1.0)
@@ -444,15 +548,15 @@ func _on_coin_collected(value: int, world_position: Vector2) -> void:
 	icon.z_index = 20
 	add_child(icon)
 	# Target: currency label center (in screen coords, which match CanvasLayer)
-	var target := Vector2(currency_label.global_position.x + currency_label.size.x / 2.0,
+	var target: Vector2 = Vector2(currency_label.global_position.x + currency_label.size.x / 2.0,
 			currency_label.global_position.y + currency_label.size.y / 2.0)
 	# Arc via a midpoint above
-	var mid := (icon.position + target) / 2.0 - Vector2(0.0, 150.0)
-	var tween := create_tween().set_ease(Tween.EASE_IN).set_trans(Tween.TRANS_QUAD)
+	var mid: Vector2 = (icon.position + target) / 2.0 - Vector2(0.0, 150.0)
+	var tween: Tween = create_tween().set_ease(Tween.EASE_IN).set_trans(Tween.TRANS_QUAD)
 	tween.tween_method(func(t: float) -> void:
 		# Quadratic bezier: P = (1-t)^2*P0 + 2*(1-t)*t*P1 + t^2*P2
-		var start_pos := world_position - Vector2(6.0, 6.0)
-		var p := (1.0 - t) * (1.0 - t) * start_pos + 2.0 * (1.0 - t) * t * mid + t * t * target
+		var start_pos: Vector2 = world_position - Vector2(6.0, 6.0)
+		var p: Vector2 = (1.0 - t) * (1.0 - t) * start_pos + 2.0 * (1.0 - t) * t * mid + t * t * target
 		icon.position = p
 		icon.scale = Vector2(1.0, 1.0).lerp(Vector2(0.5, 0.5), t)
 	, 0.0, 1.0, 0.4)
@@ -481,7 +585,7 @@ func _on_frenzy_started() -> void:
 			_frenzy_tween.kill()
 		_frenzy_label.queue_free()
 		_frenzy_label = null
-	var lbl := Label.new()
+	var lbl: Label = Label.new()
 	lbl.text = "FRENZY!"
 	lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	lbl.add_theme_font_override("font", _display_font)
@@ -502,7 +606,7 @@ func _on_frenzy_started() -> void:
 		return
 	lbl.pivot_offset = lbl.size / 2.0
 	# Intro animation: scale pop
-	var intro_tween := create_tween()
+	var intro_tween: Tween = create_tween()
 	intro_tween.tween_property(lbl, "scale", Vector2(1.2, 1.2), 0.15).from(Vector2(0.5, 0.5)).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_BACK)
 	intro_tween.tween_property(lbl, "scale", Vector2(1.0, 1.0), 0.1)
 	# Start looping pulse after intro
@@ -518,7 +622,7 @@ func _on_frenzy_ended() -> void:
 	if _frenzy_label:
 		if _frenzy_tween and _frenzy_tween.is_running():
 			_frenzy_tween.kill()
-		var fade_tween := create_tween()
+		var fade_tween: Tween = create_tween()
 		var lbl_ref: Label = _frenzy_label
 		fade_tween.tween_property(lbl_ref, "modulate:a", 0.0, 0.4)
 		fade_tween.tween_callback(func() -> void:
@@ -541,12 +645,12 @@ func _on_bomb_hit() -> void:
 func _screen_shake(intensity: float, iterations: int, step_time: float) -> void:
 	if _shake_tween and _shake_tween.is_running():
 		_shake_tween.kill()
-	var main_node := get_tree().current_scene
+	var main_node: Node = get_tree().current_scene
 	if not main_node:
 		return
 	_shake_tween = create_tween()
 	for i: int in range(iterations):
-		var offset := Vector2(randf_range(-intensity, intensity), randf_range(-intensity, intensity))
+		var offset: Vector2 = Vector2(randf_range(-intensity, intensity), randf_range(-intensity, intensity))
 		_shake_tween.tween_property(main_node, "position", offset, step_time)
 	_shake_tween.tween_property(main_node, "position", Vector2.ZERO, step_time)
 
@@ -585,22 +689,26 @@ func _create_settings_ui() -> void:
 	_settings_panel.scale = Vector2(0.8, 0.8)
 	_settings_panel.modulate.a = 0.0
 	add_child(_settings_panel)
-	_settings_panel.anchors_preset = Control.PRESET_TOP_RIGHT
-	_settings_panel.anchor_left = 1.0
-	_settings_panel.anchor_right = 1.0
-	_settings_panel.offset_left = -220.0
-	_settings_panel.offset_top = 60.0
-	_settings_panel.offset_right = -15.0
-	_settings_panel.grow_horizontal = Control.GROW_DIRECTION_BEGIN
+	_settings_panel.anchors_preset = Control.PRESET_CENTER_BOTTOM
+	_settings_panel.anchor_left = 0.5
+	_settings_panel.anchor_right = 0.5
+	_settings_panel.anchor_top = 1.0
+	_settings_panel.anchor_bottom = 1.0
+	_settings_panel.offset_left = -110.0
+	_settings_panel.offset_top = -170.0
+	_settings_panel.offset_right = 110.0
+	_settings_panel.offset_bottom = -55.0
+	_settings_panel.grow_horizontal = Control.GROW_DIRECTION_BOTH
+	_settings_panel.grow_vertical = Control.GROW_DIRECTION_BEGIN
 
-	var margin := MarginContainer.new()
+	var margin: MarginContainer = MarginContainer.new()
 	margin.add_theme_constant_override("margin_left", 10)
 	margin.add_theme_constant_override("margin_right", 10)
 	margin.add_theme_constant_override("margin_top", 8)
 	margin.add_theme_constant_override("margin_bottom", 8)
 	_settings_panel.add_child(margin)
 
-	var vbox := VBoxContainer.new()
+	var vbox: VBoxContainer = VBoxContainer.new()
 	vbox.add_theme_constant_override("separation", 6)
 	margin.add_child(vbox)
 
@@ -625,7 +733,7 @@ func _create_settings_ui() -> void:
 	# Set pivot for scale animation (top-right corner)
 	await get_tree().process_frame
 	if is_instance_valid(_settings_panel):
-		_settings_panel.pivot_offset = Vector2(_settings_panel.size.x, 0.0)
+		_settings_panel.pivot_offset = Vector2(_settings_panel.size.x / 2.0, _settings_panel.size.y)
 
 
 func _on_gear_pressed() -> void:
@@ -638,25 +746,15 @@ func _on_gear_pressed() -> void:
 
 
 func _open_settings() -> void:
-	# Close shop if open (mutual exclusion)
 	if _shop_open:
-		_shop_open = false
-		shop_toggle.text = "Shop"
-		GameManager.shop_closed.emit()
-		if _shop_tween and _shop_tween.is_running():
-			_shop_tween.kill()
-		_shop_tweening = true
-		_shop_tween = create_tween().set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_QUAD)
-		_shop_tween.tween_property(upgrade_panel, "offset_top", 0.0, 0.2)
-		_shop_tween.tween_callback(func() -> void:
-			upgrade_panel.visible = false
-			_shop_tweening = false
-		)
+		_close_shop()
 	_settings_open = true
 	_settings_backdrop.visible = true
 	_settings_panel.visible = true
 	_settings_panel.scale = Vector2(0.8, 0.8)
 	_settings_panel.modulate.a = 0.0
+	if _settings_tween and _settings_tween.is_running():
+		_settings_tween.kill()
 	_settings_tween = create_tween().set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_BACK)
 	_settings_tween.tween_property(_settings_panel, "scale", Vector2(1.0, 1.0), 0.15)
 	_settings_tween.parallel().tween_property(_settings_panel, "modulate:a", 1.0, 0.15)
@@ -665,6 +763,8 @@ func _open_settings() -> void:
 func _close_settings() -> void:
 	_settings_open = false
 	_settings_backdrop.visible = false
+	if _settings_tween and _settings_tween.is_running():
+		_settings_tween.kill()
 	_settings_tween = create_tween().set_ease(Tween.EASE_IN).set_trans(Tween.TRANS_QUAD)
 	_settings_tween.tween_property(_settings_panel, "scale", Vector2(0.8, 0.8), 0.1)
 	_settings_tween.parallel().tween_property(_settings_panel, "modulate:a", 0.0, 0.1)
@@ -677,8 +777,8 @@ func _on_backdrop_input(event: InputEvent) -> void:
 
 
 func _on_sound_toggle_pressed() -> void:
-	var bus_index := AudioServer.get_bus_index("Master")
-	var muted := not AudioServer.is_bus_mute(bus_index)
+	var bus_index: int = AudioServer.get_bus_index("Master")
+	var muted: bool = not AudioServer.is_bus_mute(bus_index)
 	AudioServer.set_bus_mute(bus_index, muted)
 	_update_sound_toggle_text()
 
@@ -688,12 +788,12 @@ func _on_fullscreen_toggle_pressed() -> void:
 
 
 func _update_sound_toggle_text() -> void:
-	var bus_index := AudioServer.get_bus_index("Master")
+	var bus_index: int = AudioServer.get_bus_index("Master")
 	_sound_toggle.text = "Sound: OFF" if AudioServer.is_bus_mute(bus_index) else "Sound: ON"
 
 
 func _update_fullscreen_toggle_text() -> void:
-	var current_mode := DisplayServer.window_get_mode()
+	var current_mode: DisplayServer.WindowMode = DisplayServer.window_get_mode()
 	if current_mode == DisplayServer.WINDOW_MODE_FULLSCREEN or current_mode == DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN:
 		_fullscreen_toggle.text = "Fullscreen: ON"
 	else:
@@ -708,7 +808,7 @@ func _update_settings_toggles() -> void:
 
 
 func _toggle_fullscreen() -> void:
-	var current_mode := DisplayServer.window_get_mode()
+	var current_mode: DisplayServer.WindowMode = DisplayServer.window_get_mode()
 	if current_mode == DisplayServer.WINDOW_MODE_FULLSCREEN or current_mode == DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN:
 		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
 	else:
@@ -826,9 +926,9 @@ func _show_milestone_celebration(amount: int) -> void:
 
 
 func _format_currency(amount: int) -> String:
-	var s := str(amount)
-	var result := ""
-	for i in range(s.length()):
+	var s: String = str(amount)
+	var result: String = ""
+	for i: int in range(s.length()):
 		if i > 0 and (s.length() - i) % 3 == 0:
 			result += ","
 		result += s[i]
@@ -837,7 +937,7 @@ func _format_currency(amount: int) -> String:
 
 func _spawn_celebration_particles() -> void:
 	for i: int in range(3):
-		var burst := CPUParticles2D.new()
+		var burst: CPUParticles2D = CPUParticles2D.new()
 		burst.emitting = true
 		burst.one_shot = true
 		burst.explosiveness = 0.8
@@ -855,10 +955,10 @@ func _spawn_celebration_particles() -> void:
 		# Use offset positions by setting emission shape
 		burst.emission_shape = CPUParticles2D.EMISSION_SHAPE_RECTANGLE
 		burst.emission_rect_extents = Vector2(200.0, 20.0)
-		var vp_size := get_viewport().get_visible_rect().size
+		var vp_size: Vector2 = get_viewport().get_visible_rect().size
 		burst.position = Vector2(vp_size.x / 2.0, vp_size.y / 2.0 + i * 200.0 - 200.0)
 		# CanvasLayer children need a Control or Node2D wrapper
-		var wrapper := Node2D.new()
+		var wrapper: Node2D = Node2D.new()
 		wrapper.position = Vector2.ZERO
 		add_child(wrapper)
 		wrapper.add_child(burst)

--- a/scripts/start_screen.gd
+++ b/scripts/start_screen.gd
@@ -23,7 +23,7 @@ func _ready() -> void:
 	var bg: ColorRect = ColorRect.new()
 	bg.color = Color(0.08, 0.08, 0.18)
 	bg.position = Vector2.ZERO
-	bg.size = Vector2(720, 1280)
+	bg.size = Vector2(2160, 1280)
 	bg.z_index = -1
 	add_child(bg)
 
@@ -33,9 +33,9 @@ func _ready() -> void:
 	add_child(coin_container)
 
 	# Spawn coins
-	for i in range(COIN_COUNT):
+	for i: int in range(COIN_COUNT):
 		var coin: Sprite2D = Sprite2D.new()
-		coin.position = Vector2(randf_range(-80.0, 800.0), randf_range(-200.0, 1280.0))
+		coin.position = Vector2(randf_range(-80.0, 2240.0), randf_range(-200.0, 1280.0))
 		coin.rotation = randf_range(0.0, TAU)
 
 		# Weighted random texture: 40% copper, 35% silver, 25% gold
@@ -62,7 +62,7 @@ func _ready() -> void:
 	var logo_backdrop: ColorRect = ColorRect.new()
 	logo_backdrop.color = Color(0.0, 0.0, 0.1, 0.6)
 	logo_backdrop.position = Vector2(0, 250)
-	logo_backdrop.size = Vector2(720, 200)
+	logo_backdrop.size = Vector2(2160, 200)
 	logo_backdrop.z_index = 5
 	add_child(logo_backdrop)
 
@@ -71,7 +71,7 @@ func _ready() -> void:
 	logo.texture = LOGO_TEXTURE
 	var logo_scale: float = 600.0 / LOGO_TEXTURE.get_width()
 	logo.scale = Vector2(logo_scale, logo_scale)
-	logo.position = Vector2(360, 350)
+	logo.position = Vector2(1080, 350)
 	logo.z_index = 10
 	add_child(logo)
 
@@ -84,7 +84,7 @@ func _ready() -> void:
 	var tap_backdrop: ColorRect = ColorRect.new()
 	tap_backdrop.color = Color(0.0, 0.0, 0.1, 0.6)
 	tap_backdrop.position = Vector2(0, 720)
-	tap_backdrop.size = Vector2(720, 80)
+	tap_backdrop.size = Vector2(2160, 80)
 	tap_backdrop.z_index = 5
 	add_child(tap_backdrop)
 
@@ -98,7 +98,7 @@ func _ready() -> void:
 	tap_label.add_theme_constant_override("outline_size", 4)
 	tap_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	tap_label.position = Vector2(0, 730)
-	tap_label.size = Vector2(720, 50)
+	tap_label.size = Vector2(2160, 50)
 	tap_label.z_index = 10
 	add_child(tap_label)
 
@@ -111,20 +111,20 @@ func _ready() -> void:
 	fade_overlay = ColorRect.new()
 	fade_overlay.color = Color(0.0, 0.0, 0.0, 0.0)
 	fade_overlay.position = Vector2.ZERO
-	fade_overlay.size = Vector2(720, 1280)
+	fade_overlay.size = Vector2(2160, 1280)
 	fade_overlay.z_index = 100
 	fade_overlay.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	add_child(fade_overlay)
 
 
 func _process(delta: float) -> void:
-	for i in range(coins.size()):
+	for i: int in range(coins.size()):
 		var coin: Sprite2D = coins[i]
 		coin.position.y += coin_speeds[i] * delta
 		coin.rotation += coin_rotation_speeds[i] * delta
 		if coin.position.y > 1480.0:
 			coin.position.y = -200.0
-			coin.position.x = randf_range(-80.0, 800.0)
+			coin.position.x = randf_range(-80.0, 2240.0)
 
 
 func _unhandled_input(event: InputEvent) -> void:


### PR DESCRIPTION
## Summary
- Viewport tripled from 720 to 2160 pixels wide (landscape) while keeping 1280 height
- Shop converted from bottom-sliding panel to centered 500x600 popup with semi-transparent backdrop, "Shop" header with close button, and click-outside-to-dismiss
- Settings gear button relocated from top-right to bottom bar alongside Shop button
- All hardcoded viewport references updated (start screen, main scene, project config)
- CLAUDE.md updated to reflect new dimensions and layout

## Test plan
- [ ] Start screen fills 2160x1280 with coins, logo centered at x=1080
- [ ] Gameplay: coins spawn across full width, catcher moves freely
- [ ] Shop button opens centered popup with backdrop dimming
- [ ] Close button (✕) and clicking outside both dismiss shop
- [ ] Settings gear next to Shop button, opens panel above bottom bar
- [ ] 120 FPS maintained, 0 orphan nodes
- [ ] Linter passes clean on all scenes

🤖 Generated with [Claude Code](https://claude.com/claude-code)