### PR TITLE
Fix shop closing when clicking upgrade buttons

### DIFF
--- a/scripts/hud.gd
+++ b/scripts/hud.gd
@@ -192,6 +192,8 @@ func _create_shop_popup_ui() -> void:
 	add_child(_shop_backdrop)
 	_shop_backdrop.anchors_preset = Control.PRESET_FULL_RECT
 	_shop_backdrop.gui_input.connect(_on_shop_backdrop_input)
+	# Move upgrade_panel after backdrop in tree so it receives input first
+	move_child(upgrade_panel, _shop_backdrop.get_index() + 1)
 	# Add header with title + close button inside upgrade panel
 	var margin_container: MarginContainer = upgrade_panel.get_child(0)
 	var scroll_container: ScrollContainer = margin_container.get_child(0)


### PR DESCRIPTION
## Summary
- Shop backdrop was intercepting all clicks before they reached upgrade panel buttons, causing the shop to close immediately on any interaction
- Fixed by reordering `upgrade_panel` after `_shop_backdrop` in the scene tree so it gets input priority

## Test plan
- [x] Lint: all 7 scenes OK
- [x] Runtime validation: 0 issues
- [x] UI validation: no issues
- [x] Shop opens, stays open on button clicks, purchases work, closes via X/backdrop/toggle
- [x] 121 FPS, 0 orphan nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)