### PR TITLE
Add Candy Crush-inspired visual effects and fix silver coin pop

### DIFF
--- a/scripts/coin.gd
+++ b/scripts/coin.gd
@@ -4,6 +4,10 @@ enum CoinType { SILVER, GOLD, FRENZY, BOMB }
 
 const TEXTURE_GOLD: Texture2D = preload("res://flexcoin.png")
 const TEXTURE_SILVER: Texture2D = preload("res://flexcoin-silver.png")
+const SHIMMER_MIN_INTERVAL: float = 2.0
+const SHIMMER_MAX_INTERVAL: float = 4.0
+const SHIMMER_FLASH_ALPHA: float = 0.85
+const SHIMMER_DURATION: float = 0.25
 
 @export var fall_speed: float = 300.0
 var value: int = 1
@@ -12,6 +16,11 @@ var coin_type: CoinType = CoinType.SILVER
 var _collected: bool = false
 var _current_speed: float = 0.0
 var _rotation_speed: float = 0.0
+var _glow_sprite: Sprite2D
+var _shimmer_timer: float = 0.0
+var _shimmer_interval: float = 0.0
+var _glow_base_alpha: float = 0.0
+var _shimmer_tween: Tween
 
 @onready var sprite: Sprite2D = $Sprite2D
 
@@ -51,6 +60,11 @@ func _process(delta: float) -> void:
 	position.y += _current_speed * delta
 	rotation += _rotation_speed * delta
 	_apply_magnet(delta)
+	_shimmer_timer += delta
+	if _shimmer_timer >= _shimmer_interval:
+		_shimmer_timer = 0.0
+		_shimmer_interval = randf_range(SHIMMER_MIN_INTERVAL, SHIMMER_MAX_INTERVAL)
+		_trigger_shimmer()
 
 
 func collect() -> void:
@@ -62,8 +76,9 @@ func collect() -> void:
 	set_deferred("monitoring", false)
 	set_deferred("monitorable", false)
 	set_process(false)
+	var pop_scale: Vector2 = sprite.scale * 1.4
 	var tween := create_tween()
-	tween.tween_property(sprite, "scale", Vector2(0.55, 0.55), 0.07).set_ease(Tween.EASE_OUT)
+	tween.tween_property(sprite, "scale", pop_scale, 0.07).set_ease(Tween.EASE_OUT)
 	tween.tween_property(sprite, "scale", Vector2(0.0, 0.0), 0.09).set_ease(Tween.EASE_IN)
 	tween.parallel().tween_property(self, "modulate:a", 0.0, 0.09)
 	tween.tween_callback(queue_free)
@@ -105,6 +120,21 @@ func _add_glow() -> void:
 			glow.modulate = Color(1.0, 0.84, 0.0, 0.2)
 	glow.z_index = -1
 	add_child(glow)
+	_glow_sprite = glow
+	_glow_base_alpha = glow.modulate.a
+	_shimmer_interval = randf_range(SHIMMER_MIN_INTERVAL, SHIMMER_MAX_INTERVAL)
+	_shimmer_timer = randf_range(0.0, _shimmer_interval)
+
+
+func _trigger_shimmer() -> void:
+	if not is_instance_valid(_glow_sprite):
+		return
+	if _shimmer_tween and _shimmer_tween.is_valid():
+		_shimmer_tween.kill()
+	_shimmer_tween = create_tween()
+	var half: float = SHIMMER_DURATION * 0.5
+	_shimmer_tween.tween_property(_glow_sprite, "modulate:a", SHIMMER_FLASH_ALPHA, half).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_QUAD)
+	_shimmer_tween.tween_property(_glow_sprite, "modulate:a", _glow_base_alpha, half).set_ease(Tween.EASE_IN).set_trans(Tween.TRANS_QUAD)
 
 
 func _add_trail() -> void:

--- a/scripts/hud.gd
+++ b/scripts/hud.gd
@@ -1,5 +1,8 @@
 extends CanvasLayer
 
+const CURRENCY_TICK_SPEED: float = 8.0
+const CURRENCY_TICK_SNAP: float = 0.5
+
 @export var upgrade_button_scene: PackedScene
 
 var _gold_flash: ColorRect
@@ -40,6 +43,9 @@ var _shop_close_button: Button
 var _bottom_bar: HBoxContainer
 var _sound_toggle: Button
 var _fullscreen_toggle: Button
+var _displayed_currency: float = 0.0
+var _target_currency: int = 0
+var _currency_ticking: bool = false
 var _display_font: Font = preload("res://assets/fonts/kenney_future.ttf")
 var _narrow_font: Font = preload("res://assets/fonts/kenney_future_narrow.ttf")
 
@@ -61,7 +67,9 @@ func _ready() -> void:
 	GameManager.combo_changed.connect(_on_combo_changed)
 	currency_label.add_theme_font_override("font", _display_font)
 	currency_label.add_theme_font_size_override("font_size", 48)
-	_on_currency_changed(GameManager.currency)
+	_displayed_currency = float(GameManager.currency)
+	_target_currency = GameManager.currency
+	currency_label.text = "Coins: %s" % _format_currency(GameManager.currency)
 	_create_upgrade_buttons()
 	shop_toggle.pressed.connect(_on_shop_toggle_pressed)
 	_create_settings_ui()
@@ -79,6 +87,14 @@ func _ready() -> void:
 
 
 func _process(delta: float) -> void:
+	# Currency tick-up animation
+	if _currency_ticking:
+		var target_f: float = float(_target_currency)
+		_displayed_currency = lerpf(_displayed_currency, target_f, 1.0 - exp(-CURRENCY_TICK_SPEED * delta))
+		if absf(_displayed_currency - target_f) < CURRENCY_TICK_SNAP:
+			_displayed_currency = target_f
+			_currency_ticking = false
+		currency_label.text = "Coins: %s" % _format_currency(int(roundf(_displayed_currency)))
 	# Rainbow combo label at 100+ combo
 	if _combo_count >= 100 and _combo_label.visible:
 		_combo_rainbow_time += delta * 1.5
@@ -87,7 +103,9 @@ func _process(delta: float) -> void:
 
 
 func _on_currency_changed(new_amount: int) -> void:
-	currency_label.text = "Coins: %s" % _format_currency(new_amount)
+	_target_currency = new_amount
+	if not _currency_ticking:
+		_currency_ticking = true
 	currency_label.custom_minimum_size.x = 280.0
 	currency_label.pivot_offset = currency_label.size / 2.0
 	_update_ascend_button()


### PR DESCRIPTION
## Summary
- **Score counter tick-up**: Currency rolls up smoothly via exponential interpolation instead of jumping instantly, Candy Crush slot-machine style
- **Coin shimmer**: Glow sprite pulses brighter every 2-4 seconds with random offset per coin, making coins feel precious
- **Silver coin pop fix**: Collection animation used absolute scale 0.55 on 1024px texture (giant flash); now uses relative `scale * 1.4`

## Test plan
- [x] Lint: all 7 scenes OK
- [x] Runtime + UI validation: 0 issues
- [x] Currency tick-up works for increases (collection) and decreases (bombs, purchases)
- [x] Coin shimmer visible on SILVER and GOLD coins, staggered timing
- [x] Silver coin collection pop proportional, no giant flash
- [x] 120 FPS, 0 orphan nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)