### PR TITLE
Add auto platform upgrade and polish

### DIFF
--- a/scenes/coin.tscn
+++ b/scenes/coin.tscn
@@ -4,14 +4,14 @@
 [ext_resource type="Texture2D" uid="uid://brw0cre686ngb" path="res://flexcoin.png" id="2_texture"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_coin"]
-radius = 24.0
+radius = 28.8
 
 [node name="Coin" type="Area2D" unique_id=921727924]
 script = ExtResource("1_script")
 
 [node name="Sprite2D" type="Sprite2D" parent="." unique_id=41759098]
 texture_filter = 6
-scale = Vector2(0.4, 0.4)
+scale = Vector2(0.6, 0.6)
 texture = ExtResource("2_texture")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=178592499]

--- a/scenes/start_screen.tscn
+++ b/scenes/start_screen.tscn
@@ -1,6 +1,6 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene format=3 uid="uid://cvm5vo2m144dq"]
 
-[ext_resource type="Script" path="res://scripts/start_screen.gd" id="1_start_screen_script"]
+[ext_resource type="Script" uid="uid://dqg7doxbwn077" path="res://scripts/start_screen.gd" id="1_start_screen_script"]
 
-[node name="StartScreen" type="Node2D"]
+[node name="StartScreen" type="Node2D" unique_id=1652460007]
 script = ExtResource("1_start_screen_script")

--- a/scripts/coin.gd
+++ b/scripts/coin.gd
@@ -122,7 +122,7 @@ func _on_screen_exited() -> void:
 func _add_glow() -> void:
 	var glow := Sprite2D.new()
 	glow.texture = sprite.texture
-	glow.scale = Vector2(0.55, 0.55)
+	glow.scale = Vector2(0.66, 0.66)
 	match coin_type:
 		CoinType.COPPER:
 			glow.modulate = Color(0.8, 0.5, 0.2, 0.25)
@@ -222,7 +222,7 @@ func _update_split_buildup(progress: float) -> void:
 	if is_instance_valid(_glow_sprite):
 		var pulse: float = (sin(_split_timer * pulse_speed) + 1.0) * 0.5
 		_glow_sprite.modulate.a = lerpf(_glow_base_alpha, pulse_alpha, pulse)
-		_glow_sprite.scale = Vector2.ONE * lerpf(0.55, 1.2, t * pulse)
+		_glow_sprite.scale = Vector2.ONE * lerpf(0.66, 1.44, t * pulse)
 	# Coin shakes with increasing intensity
 	if t > 0.3:
 		var shake: float = lerpf(0.0, 5.0, (t - 0.3) / 0.7)
@@ -261,7 +261,7 @@ func _spawn_split_coins() -> void:
 		var split: Area2D = COIN_SCENE.instantiate()
 		split.coin_type = CoinType.SILVER
 		split.position = global_position
-		split.scale = Vector2(0.65, 0.65)
+		split.scale = Vector2(0.78, 0.78)
 		get_parent().add_child(split)
 		split.sprite.texture = TEXTURE_MULTI
 		if split._trail:

--- a/scripts/start_screen.gd
+++ b/scripts/start_screen.gd
@@ -91,6 +91,7 @@ func _ready() -> void:
 	var logo_rect: TextureRect = TextureRect.new()
 	logo_rect.texture = LOGO_TEXTURE
 	logo_rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	logo_rect.texture_filter = CanvasItem.TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC
 	logo_rect.custom_minimum_size = Vector2(1100, 350)
 	logo_rect.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	logo_rect.size_flags_vertical = Control.SIZE_SHRINK_CENTER


### PR DESCRIPTION
## Summary
- Add auto-catcher platform upgrade (auto-patrolling platforms that collect coins)
- Add bomb coin type with texture, penalty mechanics, and always-spawn behavior
- Add multi coin type that splits mid-air into 3 smaller coins
- Add coin types shop upgrade with copper as default
- Increase coin size by 50% for better visibility
- Add UI sounds for shop, settings, toggles, and start screen
- Remove ascension system, rebalance upgrades, and polish coin UI
- Add anisotropic filtering to start screen logo

## Test plan
- [ ] Verify auto platforms spawn and patrol correctly at each upgrade level
- [ ] Verify bomb coins apply width penalty and currency deduction
- [ ] Verify multi coins split into 3 silver coins mid-air
- [ ] Verify coin type unlock progression (Copper → Silver → Frenzy/Bomb → Gold → Multi)
- [ ] Verify increased coin size looks correct and collision matches sprite
- [ ] Verify UI sounds play on shop/settings interactions
- [ ] Run `godot --headless --script res://tools/run_tests.gd` for unit tests
- [ ] Run `/verify` for full runtime validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)